### PR TITLE
:ambulance: Fix execution on WebGl

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solana.Unity</Product>
-    <Version>2.6.0.7</Version>
+    <Version>2.6.0.8</Version>
     <Copyright>Copyright 2022 &#169; Solana.Unity</Copyright>
     <Authors>garbles-dev</Authors>
     <PublisherName>garbles-dev</PublisherName>

--- a/build.cake
+++ b/build.cake
@@ -12,7 +12,8 @@ var testProjectsRelativePaths = new string[]
 };
 
 var target = Argument("target", "Pack");
-var configuration = Argument("configuration", "Release");
+var configuration = Argument("configuration", "Debug");
+var configurationRelease = Argument("configuration", "Release");
 var solutionFolder = "./";
 var artifactsDir = MakeAbsolute(Directory("artifacts"));
 
@@ -47,6 +48,16 @@ Task("Build")
         });
     });
 
+Task("BuildRelease")
+    .IsDependentOn("Clean")
+    .IsDependentOn("Restore")
+    .Does(() => {
+        DotNetCoreBuild(solutionFolder, new DotNetCoreBuildSettings
+        {
+            NoRestore = true,
+            Configuration = configurationRelease
+        });
+    });
     
 Task("Test")
     .IsDependentOn("Build")
@@ -94,11 +105,12 @@ Task("Report")
 
 Task("Publish")
     .IsDependentOn("Report")
+    .IsDependentOn("BuildRelease")
     .Does(() => {
         DotNetCorePublish(solutionFolder, new DotNetCorePublishSettings
         {
             NoRestore = true,
-            Configuration = configuration,
+            Configuration = configurationRelease,
             NoBuild = true,
             OutputDirectory = artifactsDir
         });
@@ -110,7 +122,7 @@ Task("Pack")
     {
         var settings = new DotNetCorePackSettings
         {
-            Configuration = configuration,
+            Configuration = configurationRelease,
             NoBuild = true,
             NoRestore = true,
             OutputDirectory = packagesDir,

--- a/src/Solana.Unity.Programs/SysVars.cs
+++ b/src/Solana.Unity.Programs/SysVars.cs
@@ -30,5 +30,9 @@ namespace Solana.Unity.Programs
         /// The public key of the Stake History System Variable.
         /// </summary>
         public static readonly PublicKey StakeHistoryKey = new("SysvarStakeHistory1111111111111111111111111");
+        /// <summary>
+        /// The public key of the Instruction Account Variable.
+        /// </summary>
+        public static readonly PublicKey InstructionAccount = new("Sysvar1nstructions1111111111111111111111111");
     }
 }

--- a/src/Solana.Unity.Rpc/Solana.Unity.Rpc.csproj
+++ b/src/Solana.Unity.Rpc/Solana.Unity.Rpc.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.*" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.*" />
     <PackageReference Include="IsExternalInit" Version="1.0.*" PrivateAssets="all" />
+    <PackageReference Include="Unity3D.SDK" Version="2021.*" />
     <ProjectReference Include="..\Solana.Unity.Wallet\Solana.Unity.Wallet.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Using UnityWebRequest when running inside Unity, as HttpClient is not fully supported in WebGL


> ⚠️ NOTE: Compilation with Debug target compile with HttpClient and can run the tests, while Release target can only run inside unity
>  


| Status  | Type  | ⚠️ Core Change |
| :---: | :---: | :---: | 
| Ready| Hotfix | Yes| 

## Problem

_HttpClient is not fully supported by Unity WebGL_


## Solution

_Runtime check if running in Unity and use UnityWebRequest instead of HttpClient_

## Other changes

- build.cake run tests using the Debug target, while the Release target contains the code to perform http requests with UnityWebRequest 

